### PR TITLE
Explicitly return self object at the end of import routine, otherwise…

### DIFF
--- a/lib/Panopto.pm
+++ b/lib/Panopto.pm
@@ -28,6 +28,7 @@ sub import
         if $args{'providerName'};
     $self->SetApplicationKey( $args{'applicationKey'} )
         if $args{'applicationKey'};
+    return $self;
 }
 
 


### PR DESCRIPTION
… subsequent calls will fail.

Fixes <https://github.com/uw-it-cte/Panopto-perl/issues/1> patch by @greenjimll.